### PR TITLE
adding localization to title in the footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,6 +2,7 @@
 
 import Link from './Link'
 import siteMetadata from '@/data/siteMetadata'
+import { maintitle } from '@/data/localeMetadata'
 import SocialIcon from '@/components/social-icons'
 
 import { useParams } from 'next/navigation'
@@ -58,7 +59,7 @@ export default function Footer() {
             <div>{` • `}</div>
             <div>{`© ${new Date().getFullYear()}`}</div>
             <div>{` • `}</div>
-            <Link href="/">{siteMetadata.title}</Link>
+            <Link href="/">{maintitle[locale]}</Link>
           </div>
           <div className="mb-8 text-sm text-gray-500 dark:text-gray-400">
             <Link href="https://github.com/PxlSyl/tailwind-nextjs-starter-blog-i18n">


### PR DESCRIPTION
at the moment the footer is using `siteMetadata.title` in the footer, which is not localized. It would be better to use the data from `localeMetadata` which has the same purpose, but is localized.